### PR TITLE
fix: builder issue by preventing router.refresh() if in iframe

### DIFF
--- a/core/app/[locale]/(default)/sales-buddy/pages/footer.tsx
+++ b/core/app/[locale]/(default)/sales-buddy/pages/footer.tsx
@@ -29,6 +29,9 @@ export default function AgentFooter() {
   };
 
   useEffect(() => {    
+    const isInIframe = window.self !== window.top;
+    if (isInIframe) return
+
     setAgentLoginStatus(localStorage.getItem('agent_login') === 'true')
     router.refresh();
   }, [agentLoginStatus]);


### PR DESCRIPTION
The builder won't work if the page is immediately refreshed when loaded.

This PR fixes the issue by preventing `router.refresh()` if the page is loaded in the builder.


https://github.com/user-attachments/assets/e6f298f6-552d-40e2-a4d5-47774af9d9a3

